### PR TITLE
feat(displayName): use full name instead of first name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ As mentioned in the step by step installation guide, there is a settings file. H
 
 * `telegram`: Object authorizing and defining the Telegram bot's behaviour
 	* `token`: The Telegram bot's token. It is needed for the bot to authenticate to the Telegram servers and be able to send and receive messages. If set to `"env"`, TediCross will read the token from the environment variable `TELEGRAM_BOT_TOKEN`
-	* `useFirstNameInsteadOfUsername`: **EXPERIMENTAL** If set to `false`, the messages sent to Discord will be tagged with the sender's username. If set to `true`, the messages sent to Discord will be tagged with the sender's first name (or nickname). Note that Discord users can't @-mention Telegram users by their first name. Defaults to `false`
+	* `useFullNameInsteadOfUsername`: **EXPERIMENTAL** If set to `false`, the messages sent to Discord will be tagged with the sender's username. If set to `true`, the messages sent to Discord will be tagged with the sender's first name and last name (or nickname). Note that Discord users can't @-mention Telegram users by their first name. Defaults to `false`
 	* `colonAfterSenderName`: Whether or not to put a colon after the name of the sender in messages from Discord to Telegram. If true, the name is displayed `Name:`. If false, it is displayed `Name`. Defaults to false
 	* `skipOldMessages`: Whether or not to skip through all previous messages cached from the telegram-side and start processing new messages ONLY. Defaults to true. Note that there is no guarantee the old messages will arrive at Discord in order
 	* `sendEmojiWithStickers`: Whether or not to send the corresponding emoji when relaying stickers to Discord

--- a/example.settings.yaml
+++ b/example.settings.yaml
@@ -1,6 +1,6 @@
 telegram:
   token: TELEGRAM_BOT_TOKEN_HERE      # Telegram bot tokens look like this: 113031530:AAH_4c5Gt9gsVu82OVNjUV7poU7PodYiNsA
-  useFirstNameInsteadOfUsername: false
+  useFullNameInsteadOfUsername: false
   colonAfterSenderName: false
   skipOldMessages: true
   sendEmojiWithStickers: true

--- a/src/settings/TelegramSettings.ts
+++ b/src/settings/TelegramSettings.ts
@@ -3,7 +3,7 @@ interface SettingProperties {
 	skipOldMessages: boolean;
 	colonAfterSenderName: boolean;
 	sendEmojiWithStickers: boolean;
-	useFirstNameInsteadOfUsername: boolean;
+	useFullNameInsteadOfUsername: boolean;
 }
 
 /******************************
@@ -13,7 +13,7 @@ interface SettingProperties {
 /** Settings for the Telegram bot */
 export class TelegramSettings {
 	private _token: string;
-	useFirstNameInsteadOfUsername: boolean;
+	useFullNameInsteadOfUsername: boolean;
 	colonAfterSenderName: boolean;
 	skipOldMessages: boolean;
 	sendEmojiWithStickers: boolean;

--- a/src/settings/TelegramSettings.ts
+++ b/src/settings/TelegramSettings.ts
@@ -23,7 +23,7 @@ export class TelegramSettings {
 	 *
 	 * @param settings The raw settings object to use
 	 * @param settings.token The bot token to use. Set to {@link TelegramSettings#GET_TOKEN_FROM_ENVIRONMENT} to read the token from the TELEGRAM_BOT_TOKEN environment variable
-	 * @param settings.useFirstNameInsteadOfUsername Whether or not to use a Telegram user's first name instead of the username when displaying the name in the Discord messages
+	 * @param settings.useFullNameInsteadOfUsername Whether or not to use a Telegram user's first name instead of the username when displaying the name in the Discord messages
 	 * @param settings.colonAfterSenderName Whether or not to put a colon after the name of the sender in messages from Discord to Telegram. If true, the name is displayed `Name:`. If false, it is displayed `Name`
 	 * @param settings.skipOldMessages Whether or not to skip through all previous messages cached from the telegram-side and start processing new messages ONLY
 	 * @param settings.sendEmojiWithStickers Whether or not to send the corresponding emoji when relaying stickers to Discord
@@ -38,7 +38,7 @@ export class TelegramSettings {
 		this._token = settings.token;
 
 		/** Whether or not to use a Telegram user's first name instead of the username when displaying the name in the Discord messages */
-		this.useFirstNameInsteadOfUsername = settings.useFirstNameInsteadOfUsername;
+		this.useFullNameInsteadOfUsername = settings.useFullNameInsteadOfUsername;
 
 		/** Whether or not to put a colon after the name of the sender in messages from Discord to Telegram. If true, the name is displayed `Name:`. If false, it is displayed `Name` */
 		this.colonAfterSenderName = settings.colonAfterSenderName;
@@ -88,9 +88,9 @@ export class TelegramSettings {
 			throw new Error("`settings.token` must be a string");
 		}
 
-		// Check that useFirstNameInsteadOfUsername is a boolean
-		if (Boolean(settings.useFirstNameInsteadOfUsername) !== settings.useFirstNameInsteadOfUsername) {
-			throw new Error("`settings.useFirstNameInsteadOfUsername` must be a boolean");
+		// Check that useFullNameInsteadOfUsername is a boolean
+		if (Boolean(settings.useFullNameInsteadOfUsername) !== settings.useFullNameInsteadOfUsername) {
+			throw new Error("`settings.useFullNameInsteadOfUsername` must be a boolean");
 		}
 
 		// Check that colonAfterSenderName is a boolean
@@ -118,7 +118,7 @@ export class TelegramSettings {
 	static get DEFAULTS() {
 		return {
 			token: TelegramSettings.GET_TOKEN_FROM_ENVIRONMENT,
-			useFirstNameInsteadOfUsername: false,
+			useFullNameInsteadOfUsername: false,
 			colonAfterSenderName: false,
 			skipOldMessages: true,
 			sendEmojiWithStickers: true

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -24,7 +24,7 @@ interface From {
  * @memberof From
  */
 export function createFromObj(firstName: string, lastName: string | undefined, username: string | undefined): From {
-	var fullName = firstName.concat(lastName);
+	var fullName = firstName.concat(lastName.toString());
 	return {
 		firstName,
 		lastName,

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -24,7 +24,7 @@ interface From {
  * @memberof From
  */
 export function createFromObj(firstName: string, lastName: string, username: string | undefined): From {
-	var fullName = lastName ? firstName.concat(lastName.toString()) : firstName;
+	var fullName = lastName ? firstName.concat(" ",lastName.toString()) : firstName;
 	return {
 		firstName,
 		lastName,

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -8,8 +8,8 @@ import { Message, User } from "telegraf/typings/core/types/typegram";
 interface From {
 	firstName: string;
 	lastName?: string;
+	fullName?: string;
 	username?: string;
-	fullname?: string;
 }
 
 /**
@@ -27,8 +27,8 @@ export function createFromObj(firstName: string, lastName: string | undefined, u
 	return {
 		firstName,
 		lastName,
-		username,
-		(firstName + ' ' + lastName).trim()
+		(firstName + ' ' + lastName).trim(),
+		username
 	};
 }
 

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -81,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName").concat(' ',R.prop("lastName")).trim(),
+		R.prop("firstName").toString().concat(' ',R.prop("lastName").toString()).trim(),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -23,8 +23,8 @@ interface From {
  *
  * @memberof From
  */
-export function createFromObj(firstName: string, lastName: string | undefined, username: string | undefined): From {
-	var fullName = firstName.concat(lastName.toString());
+export function createFromObj(firstName: string, lastName: string, username: string | undefined): From {
+	var fullName = lastName ? firstName.concat(lastName.toString()) : firstName;
 	return {
 		firstName,
 		lastName,

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -24,10 +24,11 @@ interface From {
  * @memberof From
  */
 export function createFromObj(firstName: string, lastName: string | undefined, username: string | undefined): From {
+	var fullName = firstName.concat(lastName);
 	return {
 		firstName,
 		lastName,
-		firstName,
+		fullName,
 		username
 	};
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -9,6 +9,7 @@ interface From {
 	firstName: string;
 	lastName?: string;
 	username?: string;
+	fullname?: string;
 }
 
 /**
@@ -26,7 +27,8 @@ export function createFromObj(firstName: string, lastName: string | undefined, u
 	return {
 		firstName,
 		lastName,
-		username
+		username,
+		(firstName + ' ' + lastName).trim()
 	};
 }
 
@@ -73,15 +75,15 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 /**
  * Makes a display name out of a from object
  *
- * @param useFirstNameInsteadOfUsername Whether or not to always use the first name instead of the username
+ * @param useFullNameInsteadOfUsername
  * @param from The from object
  *
  * @returns The display name
  */
-export function makeDisplayName(useFirstNameInsteadOfUsername: boolean, from: From) {
+export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
-		from => useFirstNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName"),
+		from => useFullNameInsteadOfUsername || R.isNil(from.username),
+		R.prop("fullName"),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -81,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName").toString().concat(R.prop("lastName").toString()),
+		R.prop("firstName").concat(R.prop("lastName").toString()),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -8,6 +8,7 @@ import { Message, User } from "telegraf/typings/core/types/typegram";
 interface From {
 	firstName: string;
 	lastName?: string;
+	fullName?: string;
 	username?: string;
 }
 
@@ -26,6 +27,7 @@ export function createFromObj(firstName: string, lastName: string | undefined, u
 	return {
 		firstName,
 		lastName,
+		firstName,
 		username
 	};
 }
@@ -81,7 +83,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName").toString().concat(R.prop("lastName")),
+		R.prop("fullName"),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -81,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName").concat(R.prop("lastName").toString()),
+		R.prop("firstName").toString().concat(R.prop("lastName")),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -81,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		(R.prop("firstName") + ' ' + R.prop("lastName")).trim(),
+		R.prop("firstName").concat(' ',R.prop("lastName")).trim(),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -8,7 +8,6 @@ import { Message, User } from "telegraf/typings/core/types/typegram";
 interface From {
 	firstName: string;
 	lastName?: string;
-	fullName?: string;
 	username?: string;
 }
 
@@ -27,7 +26,6 @@ export function createFromObj(firstName: string, lastName: string | undefined, u
 	return {
 		firstName,
 		lastName,
-		(firstName + ' ' + lastName).trim(),
 		username
 	};
 }
@@ -83,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("fullName"),
+		(R.prop("firstName") + ' ' + R.prop("lastName")).trim(),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/From.ts
+++ b/src/telegram2discord/From.ts
@@ -81,7 +81,7 @@ export function createFromObjFromChat(chat: Record<string, any>) {
 export function makeDisplayName(useFullNameInsteadOfUsername: boolean, from: From) {
 	return R.ifElse(
 		from => useFullNameInsteadOfUsername || R.isNil(from.username),
-		R.prop("firstName").toString().concat(' ',R.prop("lastName").toString()).trim(),
+		R.prop("firstName").toString().concat(R.prop("lastName").toString()),
 		R.prop("username")
 	)(from);
 }

--- a/src/telegram2discord/middlewares.ts
+++ b/src/telegram2discord/middlewares.ts
@@ -502,7 +502,7 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 	ctx.tediCross.prepared = await Promise.all(
 		R.map(async (bridge: Bridge) => {
 			// Get the name of the sender of this message
-			const senderName = makeDisplayName(ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername, tc.from);
+			const senderName = makeDisplayName(ctx.TediCross.settings.telegram.useFullNameInsteadOfUsername, tc.from);
 
 			// Make the header
 			// WARNING! Butt-ugly code! If you see a nice way to clean this up, please do it
@@ -510,7 +510,7 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 				// Get the name of the original sender, if this is a forward
 				const originalSender = R.isNil(tc.forwardFrom)
 					? null
-					: makeDisplayName(ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername, tc.forwardFrom);
+					: makeDisplayName(ctx.TediCross.settings.telegram.useFullNameInsteadOfUsername, tc.forwardFrom);
 				// Get the name of the replied-to user, if this is a reply
 				const repliedToName = R.isNil(tc.replyTo)
 					? null
@@ -522,7 +522,7 @@ async function addPreparedObj(ctx: TediCrossContext, next: () => void) {
 							),
 							R.compose(
 								R.partial(makeDisplayName, [
-									ctx.TediCross.settings.telegram.useFirstNameInsteadOfUsername
+									ctx.TediCross.settings.telegram.useFullNameInsteadOfUsername
 								]),
 								//@ts-ignore
 								R.prop("originalFrom")


### PR DESCRIPTION
Discord messages will display the full name of TG members, instead of only the first name.